### PR TITLE
Fix Vite startup issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Browse to http://localhost:5174 to access the React-based dashboard. The dashboa
 ```bash
 cd web && npm install && npm run dev
 ```
+Ensure you have Node.js and npm installed. The `start_all.sh` script will
+automatically install these dependencies if `node_modules` is missing.
 
 ### Unified Startup Script
 
@@ -93,8 +95,9 @@ chmod +x start_all.sh
 ./start_all.sh
 ```
 
-This will launch the API, Celery worker, Celery beat scheduler, and the React dashboard,
-automatically open your browser to `http://localhost:5174`, and stream logs via WebSocket.
+This will launch the API, Celery worker, Celery beat scheduler, and the React dashboard.
+If Node dependencies are missing, the script installs them automatically before starting Vite.
+Your browser will open to `http://localhost:5174` and logs will stream via WebSocket.
 
 ### Running Celery Worker
 

--- a/start_all.sh
+++ b/start_all.sh
@@ -20,6 +20,16 @@ celery -A service.celery_app.celery_app beat --loglevel=info &
 BEAT_PID=$!
 
 echo "Starting Frontend..."
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is not installed. Please install Node.js and npm to run the frontend." >&2
+  exit 1
+fi
+
+if [ ! -d web/node_modules ]; then
+  echo "Installing frontend dependencies..."
+  (cd web && npm install)
+fi
+
 cd web && npm run dev &
 FRONTEND_PID=$!
 


### PR DESCRIPTION
## Summary
- update docs for running the frontend and mention automatic dependency install
- improve `start_all.sh` to verify npm is installed and install `web` dependencies automatically if missing

## Testing
- `npm install`
- `npm run dev`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686edf9c12008324af51c70c7a739dbe