### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000
+CMD ["uvicorn", "service.api:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add minimal Dockerfile to run the FastAPI service

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `docker build -t obelisk-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_686ee12ca54483249739f84640e91b56