### PR TITLE
Add health endpoints and CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+          pre-commit install-hooks
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort
+        language_version: python3
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.7
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        args: ["--ignore-missing-imports"]

--- a/README.md
+++ b/README.md
@@ -17,8 +17,13 @@ This project defines an agent system that automates creating complete software s
    ```bash
    pip install -r requirements.txt
    ```
-3. Copy `.env.example` to `.env` and populate with your API keys, Codex CLI path, and LLAMA_MODEL_PATH.
-4. (Optional) Run the LLaMA setup script to download and configure a base model:
+3. Install and run `pre-commit` hooks:
+   ```bash
+   pip install pre-commit
+   pre-commit install
+   ```
+4. Copy `.env.example` to `.env` and populate with your API keys, Codex CLI path, and LLAMA_MODEL_PATH.
+5. (Optional) Run the LLaMA setup script to download and configure a base model:
    ```bash
    scripts/setup_llama.py --model decapoda-research/llama-7b-hf --dest ./models/llama
    ```
@@ -117,6 +122,8 @@ Endpoints:
 - `POST /tasks` to enqueue an agent task (specify `agent` and `params` JSON); returns a task ID immediately.
 - `GET /tasks/{id}` to check status/result.
 - `GET /memory/{agent_name}` to retrieve recent memory entries.
+- `GET /healthz` for a simple health check.
+- `GET /version` to retrieve the running commit hash.
 
 ## Prompt Chaining & Reasoning Logs
 


### PR DESCRIPTION
## Summary
- add a `.pre-commit-config.yaml` setup with Black, isort, ruff, and mypy
- add GitHub Actions workflow to run pre-commit on pushes and PRs
- expose `/healthz` and `/version` endpoints in `service/api.py`
- document pre-commit usage and new endpoints in README

## Testing
- `pytest -q`
- `pre-commit run --files service/api.py README.md .pre-commit-config.yaml .github/workflows/ci.yml` *(fails: ruff/mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ee3a5e8bc8324bd572e276a983a57