### PR TITLE
Update README to match available features

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ uvicorn service.api:app --reload
 Browse to http://localhost:5174 to access the React-based dashboard. The dashboard now supports:
 - Submitting tasks and viewing live status/results
 - Refreshable Task History table via `/tasks_all`
-- Real-time log streaming via WebSocket at `/ws/logs`
 
 ```bash
 cd web && npm install && npm run dev
@@ -102,7 +101,7 @@ chmod +x start_all.sh
 
 This will launch the API, Celery worker, Celery beat scheduler, and the React dashboard.
 If Node dependencies are missing, the script installs them automatically before starting Vite.
-Your browser will open to `http://localhost:5174` and logs will stream via WebSocket.
+Your browser will open to `http://localhost:5174`.
 
 ### Running Celery Worker
 


### PR DESCRIPTION
## Summary
- remove claim of WebSocket logs route from dashboard docs

## Testing
- `pre-commit run --files README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ee5580ef483248d81c1f0aad9ed10