### PR TITLE
Fix Celery startup by ensuring Redis is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ cd web && npm install && npm run dev
 Ensure you have Node.js and npm installed. The `start_all.sh` script will
 automatically install these dependencies if `node_modules` is missing.
 
+### Redis Requirement
+
+Celery relies on Redis as its message broker and result backend. Make sure a
+`redis-server` is installed and running on `localhost:6379` before starting the
+API or worker processes. The `start_all.sh` script will try to launch Redis
+automatically if the command is available. On Ubuntu you can install it via
+`sudo apt-get install redis-server`; on macOS use `brew install redis`.
+
 ### Unified Startup Script
 
 Instead of managing multiple terminals, use the provided `start_all.sh` script at the project root:

--- a/start_all.sh
+++ b/start_all.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 set -e
 
+# Ensure Redis is running for Celery
+if command -v redis-cli >/dev/null 2>&1; then
+  if ! redis-cli ping >/dev/null 2>&1; then
+    echo "Starting Redis..."
+    redis-server --daemonize yes
+    # Give Redis a moment to spin up
+    sleep 1
+  fi
+else
+  echo "Redis is required but not installed. Please install redis-server." >&2
+  exit 1
+fi
+
 # Activate venv if exists
 if [ -f .venv/bin/activate ]; then
   source .venv/bin/activate


### PR DESCRIPTION
## Summary
- start `redis-server` automatically from `start_all.sh`
- document Redis requirement in README

## Testing
- `pre-commit run --files start_all.sh README.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_686f30e43ec0832484b64ea0aa508342