### PR TITLE
Update startup script to auto-install Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,14 @@ Browse to http://localhost:5174 to access the React-based dashboard. The dashboa
 cd web && npm install && npm run dev
 ```
 Ensure you have Node.js and npm installed. The `start_all.sh` script will
-automatically install these dependencies if `node_modules` is missing.
+automatically pull the latest code, install missing dependencies (including
+Redis), and bootstrap the frontend if `node_modules` is missing.
 
 ### Redis Requirement
 
-Celery relies on Redis as its message broker and result backend. Make sure a
-`redis-server` is installed and running on `localhost:6379` before starting the
-API or worker processes. The `start_all.sh` script will try to launch Redis
-automatically if the command is available. On Ubuntu you can install it via
-`sudo apt-get install redis-server`; on macOS use `brew install redis`.
+Celery relies on Redis as its message broker and result backend. The startup
+script now checks for `redis-server` and installs it using `apt-get` or `brew`
+if necessary, then launches the service automatically.
 
 ### Unified Startup Script
 

--- a/start_all.sh
+++ b/start_all.sh
@@ -1,6 +1,33 @@
 #!/usr/bin/env bash
 set -e
 
+echo "Updating repository..."
+git pull --ff-only
+
+# Install missing system dependencies
+install_packages=()
+
+if ! command -v npm >/dev/null 2>&1; then
+  install_packages+=(nodejs npm)
+fi
+
+if ! command -v redis-server >/dev/null 2>&1; then
+  install_packages+=(redis-server)
+fi
+
+if [ ${#install_packages[@]} -gt 0 ]; then
+  echo "Installing packages: ${install_packages[*]}"
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y "${install_packages[@]}"
+  elif command -v brew >/dev/null 2>&1; then
+    brew install "${install_packages[@]}"
+  else
+    echo "Unsupported package manager. Please install ${install_packages[*]} manually." >&2
+    exit 1
+  fi
+fi
+
 # Ensure Redis is running for Celery
 if command -v redis-cli >/dev/null 2>&1; then
   if ! redis-cli ping >/dev/null 2>&1; then
@@ -10,7 +37,7 @@ if command -v redis-cli >/dev/null 2>&1; then
     sleep 1
   fi
 else
-  echo "Redis is required but not installed. Please install redis-server." >&2
+  echo "Redis is required but redis-cli is missing even after install attempt." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- extend `start_all.sh` to `git pull` and install missing packages
- ensure Redis gets installed if absent and started automatically
- document new behaviour in README

## Testing
- `pre-commit run --files start_all.sh README.md`

------
https://chatgpt.com/codex/tasks/task_e_686f3362ab488324a19512acfc2748ad